### PR TITLE
fetch depdencies instead of assuming them

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 default:
-	go install github.com/dynport/gocloud/gocloud
+	go get github.com/dynport/gocloud/gocloud
 
 test:
 	cd jiffybox && go test -v


### PR DESCRIPTION
go get helps to ensure all dependecies are installed instead of assuming
they are there. if they are there, they won't be touched.

This behavior is a bit more user friendly.

@tobstarr Please take a look
