### PR TITLE
use default http client

### DIFF
--- a/aws/client.go
+++ b/aws/client.go
@@ -41,9 +41,8 @@ func QueryPrefix(version, action string) string {
 // list of endpoints
 func (client *Client) DoSignedRequest(method string, endpoint, action string, extraAttributes map[string]string) (rsp *Response, e error) {
 	request, e := http.NewRequest("GET", endpoint+"?"+action, nil)
-	httpClient := &http.Client{}
 	client.SignAwsRequestV2(request, time.Now())
-	raw, e := httpClient.Do(request)
+	raw, e := http.DefaultClient.Do(request)
 	if e != nil {
 		return rsp, e
 	}


### PR DESCRIPTION
`&http.Client{}` actually generates the `http.DefaultClient`, which can be
used concurrently already.

In order to re-use existing idle connections to aws and generate less garbage,
just use http.DefaultClient.

The proper connection management and idle pooling is already provided by the
default transport.

@tobstarr please take a look. If you explicitly want to avoid the pooling for certain reasons, please tell me.

net/http is really awesome by default :-)
