### PR TITLE
actually use the passed http method

### DIFF
--- a/aws/client.go
+++ b/aws/client.go
@@ -40,7 +40,7 @@ func QueryPrefix(version, action string) string {
 
 // list of endpoints
 func (client *Client) DoSignedRequest(method string, endpoint, action string, extraAttributes map[string]string) (rsp *Response, e error) {
-	request, e := http.NewRequest("GET", endpoint+"?"+action, nil)
+	request, e := http.NewRequest(method, endpoint+"?"+action, nil)
 	client.SignAwsRequestV2(request, time.Now())
 	raw, e := http.DefaultClient.Do(request)
 	if e != nil {


### PR DESCRIPTION
In order to resolve current bugs in aws/elb and aws/ec2 APIs,
just use the method passed in.

@tobstarr please take a look. elb and ec2 APIs use other HTTP verbs as GET, so these APIs just work now.
