### PR TITLE
use client.Endpoint() everywhere

### DIFF
--- a/aws/cloudformation/main.go
+++ b/aws/cloudformation/main.go
@@ -20,6 +20,14 @@ func NewFromEnv() *Client {
 	return &Client{Client: aws.NewFromEnv()}
 }
 
+func (client *Client) Endpoint() string {
+	prefix := "https://cloudformation"
+	if client.Client.Region != "" {
+		prefix += "." + client.Client.Region
+	}
+	return prefix + ".amazonaws.com"
+}
+
 func (client *Client) loadCloudFormationResource(action string, params url.Values, i interface{}) error {
 	req, e := client.signedCloudFormationRequest(action, params)
 
@@ -62,7 +70,6 @@ func defaultParams() url.Values {
 
 var (
 	ErrorNotFound = fmt.Errorf("Error not found")
-	urlRoot       = "https://cloudformation.eu-west-1.amazonaws.com/"
 )
 
 func (client *Client) signedCloudFormationRequest(action string, params url.Values) (*http.Request, error) {
@@ -73,7 +80,7 @@ func (client *Client) signedCloudFormationRequest(action string, params url.Valu
 		}
 	}
 	values.Add("Action", action)
-	theUrl := urlRoot + "?" + values.Encode()
+	theUrl := client.Endpoint() + "?" + values.Encode()
 	req, e := http.NewRequest("GET", theUrl, nil)
 	if e != nil {
 		return nil, e

--- a/aws/cloudwatch/metric.go
+++ b/aws/cloudwatch/metric.go
@@ -24,19 +24,26 @@ type ListMetricsResponse struct {
 }
 
 const (
-	ENDPOINT = "https://monitoring.us-east-1.amazonaws.com"
-	VERSION  = "2010-08-01"
+	VERSION = "2010-08-01"
 )
 
 type Client struct {
 	*aws.Client
 }
 
+func (client *Client) Endpoint() string {
+	prefix := "https://monitoring"
+	if client.Client.Region != "" {
+		prefix += "." + client.Client.Region
+	}
+	return prefix + ".amazonaws.com"
+}
+
 func (client *Client) ListMetrics() (rsp *ListMetricsResponse, e error) {
 	values := &url.Values{}
 	values.Add("Version", VERSION)
 	values.Add("Action", "ListMetrics")
-	raw, e := client.DoSignedRequest("GET", ENDPOINT, values.Encode(), nil)
+	raw, e := client.DoSignedRequest("GET", client.Endpoint(), values.Encode(), nil)
 	if e != nil {
 		return nil, e
 	}

--- a/aws/ec2/addresses.go
+++ b/aws/ec2/addresses.go
@@ -20,7 +20,7 @@ type DescribeAddressesResponse struct {
 }
 
 func (client *Client) DescribeAddresses() (addresses []*Address, e error) {
-	raw, e := client.DoSignedRequest("GET", ENDPOINT, queryForAction("DescribeAddresses"), nil)
+	raw, e := client.DoSignedRequest("GET", client.Endpoint(), queryForAction("DescribeAddresses"), nil)
 	if e != nil {
 		return addresses, e
 	}

--- a/aws/ec2/describe_subnets.go
+++ b/aws/ec2/describe_subnets.go
@@ -21,7 +21,7 @@ func (client *Client) DescribeSubnets(params *DescribeSubnetsParameters) (*Descr
 		"Version": {API_VERSIONS_EC2},
 	}
 	applyFilters(query, params.Filters)
-	raw, e := client.DoSignedRequest("GET", ENDPOINT, query.Encode(), nil)
+	raw, e := client.DoSignedRequest("GET", client.Endpoint(), query.Encode(), nil)
 	if e != nil {
 		return nil, e
 	}

--- a/aws/ec2/ec2.go
+++ b/aws/ec2/ec2.go
@@ -16,7 +16,7 @@ type DescribeKeyPairsResponse struct {
 }
 
 func (client *Client) DescribeKeyPairs() (pairs []*KeyPair, e error) {
-	raw, e := client.DoSignedRequest("GET", ENDPOINT, queryForAction("DescribeKeyPairs"), nil)
+	raw, e := client.DoSignedRequest("GET", client.Endpoint(), queryForAction("DescribeKeyPairs"), nil)
 	if e != nil {
 		return pairs, e
 	}

--- a/aws/ec2/images.go
+++ b/aws/ec2/images.go
@@ -26,7 +26,7 @@ func (client *Client) DescribeImagesWithFilter(filter *ImageFilter) (images Imag
 	for i, id := range filter.ImageIds {
 		values.Add("ImageId."+strconv.Itoa(i+1), id)
 	}
-	raw, e := client.DoSignedRequest("GET", ENDPOINT, values.Encode(), nil)
+	raw, e := client.DoSignedRequest("GET", client.Endpoint(), values.Encode(), nil)
 	if e != nil {
 		return
 	}
@@ -70,7 +70,7 @@ func (client *Client) CreateImage(opts *CreateImageOptions) (rsp *CreateImageRes
 		values.Add("NoReboot", "true")
 	}
 
-	raw, e := client.DoSignedRequest("GET", ENDPOINT, values.Encode(), nil)
+	raw, e := client.DoSignedRequest("GET", client.Endpoint(), values.Encode(), nil)
 	if e != nil {
 		return nil, e
 	}

--- a/aws/ec2/security_groups.go
+++ b/aws/ec2/security_groups.go
@@ -55,7 +55,7 @@ func (client *Client) DescribeSecurityGroups(params *DescribeSecurityGroupsParam
 	if search := params.query(); search != "" {
 		q += "&" + search
 	}
-	raw, e := client.DoSignedRequest("GET", ENDPOINT, q, nil)
+	raw, e := client.DoSignedRequest("GET", client.Endpoint(), q, nil)
 	if e != nil {
 		return groups, e
 	}

--- a/aws/ec2/spot_instances.go
+++ b/aws/ec2/spot_instances.go
@@ -53,7 +53,7 @@ func (client *Client) DescribeSpotPriceHistory(filter *SpotPriceFilter) (prices 
 	}
 	query += "&" + values.Encode()
 	log.Println(query)
-	raw, e := client.DoSignedRequest("GET", ENDPOINT, query, nil)
+	raw, e := client.DoSignedRequest("GET", client.Endpoint(), query, nil)
 	if e != nil {
 		return prices, e
 	}


### PR DESCRIPTION
This removes all of the hardcoded eu-west-1 references in favor of client.Endpoint() which has the region injected from elsewhere (e.g. env variable).
