### PR TITLE
fix price type

### DIFF
--- a/digitalocean/v2/digitalocean/droplets.go
+++ b/digitalocean/v2/digitalocean/droplets.go
@@ -158,7 +158,7 @@ type Size struct {
 	VCpus         int         `json:"v_cpus,omitempty"`
 	Disk          int         `json:"disk,omitempty"`
 	Transfer      interface{} `json:"transfer,omitempty"`
-	PriceMonthley string      `json:"price_monthley,omitempty"`
-	PriceHourly   string      `json:"price_hourly,omitempty"`
+	PriceMonthley float32     `json:"price_monthley,omitempty"`
+	PriceHourly   float32     `json:"price_hourly,omitempty"`
 	Regions       []string    `json:"regions,omitempty"`
 }


### PR DESCRIPTION
API looks like this:

```
      "size":{
        "slug":"512mb",
        "transfer":1,
        "price_monthly":5.0,
        "price_hourly":0.00744
      },
```

Without this fix I was getting:

```
error listing instances json: cannot unmarshal number into Go value of type string
```
