### PR TITLE
add ListStackResources action

### DIFF
--- a/aws/cloudformation/list_stack_resources.go
+++ b/aws/cloudformation/list_stack_resources.go
@@ -1,0 +1,51 @@
+package cloudformation
+
+import "encoding/xml"
+
+type ListStackResourcesResponse struct {
+	XMLName                          xml.Name                          `xml:"ListStackResourcesResponse"`
+	InternalListStackResourcesResult *InternalListStackResourcesResult `xml:"ListStackResourcesResult"`
+}
+
+type InternalListStackResourcesResult struct {
+	NextToken      *string          `xml:"NextToken"`
+	StackResources []*StackResource `xml:"StackResourceSummaries>member"`
+}
+
+type ListStackResourcesResult struct {
+	StackResources []*StackResource
+}
+
+type ListStackResourcesParameters struct {
+	LogicalResourceId  string
+	PhysicalResourceId string
+	StackName          string
+}
+
+func (client *Client) ListStackResources(params ListStackResourcesParameters) (*ListStackResourcesResult, error) {
+	var NextToken string
+	result := &ListStackResourcesResult{
+		StackResources: []*StackResource{},
+	}
+	for {
+		r := &ListStackResourcesResponse{}
+		values := Values{
+			"StackName":          params.StackName,
+			"PhysicalResourceId": params.PhysicalResourceId,
+			"LogicalResourceId":  params.LogicalResourceId,
+			"NextToken":          NextToken,
+		}
+		e := client.loadCloudFormationResource("ListStackResources", values, r)
+		if e != nil {
+			return nil, e
+		}
+
+		result.StackResources = append(result.StackResources, r.InternalListStackResourcesResult.StackResources...)
+		if r.InternalListStackResourcesResult.NextToken == nil {
+			break
+		} else {
+			NextToken = *r.InternalListStackResourcesResult.NextToken
+		}
+	}
+	return result, nil
+}


### PR DESCRIPTION
the gocloud client implements `DescribeStackResources` which only retrieves the first 100 resources in a cloud formation stack. If there are more than 100 resources, `ListStackResources` needs to be used with support for pagination. 

This PR adds support for `ListStackResources` action.

Signed-off-by: Chris Piraino <cpiraino@pivotal.io>